### PR TITLE
Add automatic tab-closing Chrome extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-hello world
+# Tab Closer Chrome Extension
+
+This extension automatically closes tabs that have been open for more than a few days. By default, tabs open for over **3 days** are closed.
+
+## Installation
+
+1. Clone or download this repository.
+2. Open Chrome and navigate to `chrome://extensions/`.
+3. Enable **Developer mode**.
+4. Click **Load unpacked** and select this folder.
+
+The extension will run in the background and periodically close old tabs.
+
+You can change the maximum open time by editing `MAX_DAYS_OPEN` in `background.js`.

--- a/background.js
+++ b/background.js
@@ -1,0 +1,95 @@
+const MAX_DAYS_OPEN = 3; // number of days after which tabs are closed
+const CHECK_INTERVAL_MINUTES = 60; // interval to check tabs
+
+// Get stored tab timestamps
+function getTabTimestamps(callback) {
+  chrome.storage.local.get('tabTimestamps', (data) => {
+    callback(data.tabTimestamps || {});
+  });
+}
+
+// Save tab timestamps
+function saveTabTimestamps(timestamps) {
+  chrome.storage.local.set({ tabTimestamps: timestamps });
+}
+
+// Record creation time for a tab
+function recordTab(tabId) {
+  getTabTimestamps((timestamps) => {
+    if (!timestamps[tabId]) {
+      timestamps[tabId] = Date.now();
+      saveTabTimestamps(timestamps);
+    }
+  });
+}
+
+// Remove record for closed tab
+function removeTab(tabId) {
+  getTabTimestamps((timestamps) => {
+    if (timestamps[tabId]) {
+      delete timestamps[tabId];
+      saveTabTimestamps(timestamps);
+    }
+  });
+}
+
+// Check all tabs and close ones open for too long
+function closeOldTabs() {
+  getTabTimestamps((timestamps) => {
+    chrome.tabs.query({}, (tabs) => {
+      const now = Date.now();
+      const limit = MAX_DAYS_OPEN * 24 * 60 * 60 * 1000;
+      for (const tab of tabs) {
+        const openTime = timestamps[tab.id];
+        if (openTime && now - openTime > limit) {
+          chrome.tabs.remove(tab.id);
+          delete timestamps[tab.id];
+        } else if (!openTime) {
+          // Record timestamp for tabs we haven't seen
+          timestamps[tab.id] = now;
+        }
+      }
+      saveTabTimestamps(timestamps);
+    });
+  });
+}
+
+// On startup, record existing tabs
+chrome.runtime.onStartup.addListener(() => {
+  chrome.tabs.query({}, (tabs) => {
+    const now = Date.now();
+    getTabTimestamps((timestamps) => {
+      for (const tab of tabs) {
+        if (!timestamps[tab.id]) {
+          timestamps[tab.id] = now;
+        }
+      }
+      saveTabTimestamps(timestamps);
+    });
+  });
+});
+
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.tabs.query({}, (tabs) => {
+    const now = Date.now();
+    const timestamps = {};
+    for (const tab of tabs) {
+      timestamps[tab.id] = now;
+    }
+    saveTabTimestamps(timestamps);
+  });
+});
+
+chrome.tabs.onCreated.addListener((tab) => {
+  recordTab(tab.id);
+});
+
+chrome.tabs.onRemoved.addListener((tabId) => {
+  removeTab(tabId);
+});
+
+// Periodically check tabs
+setInterval(closeOldTabs, CHECK_INTERVAL_MINUTES * 60 * 1000);
+
+// Also run once on startup
+closeOldTabs();

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,10 @@
+{
+  "manifest_version": 3,
+  "name": "Tab Closer",
+  "description": "Automatically closes tabs that have been open for several days.",
+  "version": "1.0",
+  "permissions": ["tabs", "storage"],
+  "background": {
+    "service_worker": "background.js"
+  }
+}


### PR DESCRIPTION
## Summary
- implement basic Chrome extension that records tab creation time and closes them after a few days
- document installation and configuration in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684279c88bb0832f889612f9ddb5dceb